### PR TITLE
kdbg search was incorrect

### DIFF
--- a/bulk_volatility_scanner.py
+++ b/bulk_volatility_scanner.py
@@ -150,6 +150,8 @@ class MemoryImage(object):
 
 			kdbg_regex = re.search('KDBG : ([^\n]*)', data)
 			auto_kdbg = kdbg_regex.group(1)
+			if ("L" in auto_kdbg[-2:]):
+				auto_kdbg = auto_kdbg[:-2]
 
 		# If not already provided, select the first suggested profile
 		if not self.profile:


### PR DESCRIPTION
imageinfo output has an "L" at the end of the KDBG output, added a check and a remove function